### PR TITLE
fix: drop qs2; use the nlmixr2lib::modeldb dataset directly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,8 +36,7 @@ Imports:
     lotri,
     ggplot2,
     checkmate,
-    xfun,
-    qs2
+    xfun
 RoxygenNote: 7.3.3
 Suggests:
     testthat (>= 3.1.1)

--- a/R/pkmodule.R
+++ b/R/pkmodule.R
@@ -4,7 +4,9 @@
 
 .pkmodlib <- function()  {
   if(is.null(.modellib$modeldb)) {
-    .modellib$modeldb <- qs2::qs_read(system.file("modeldb.qs2", package="nlmixr2lib"))
+    # the exported dataset is the same object nlmixr2lib writes to its
+    # inst/ copy, so read it directly instead of a serialized file
+    .modellib$modeldb <- nlmixr2lib::modeldb
   }
   .modellib$modeldb
 }


### PR DESCRIPTION
## Problem

`.pkmodlib()` reached into nlmixr2lib's installed files to read its serialized copy of the model database:

```r
.modellib$modeldb <- qs2::qs_read(system.file("modeldb.qs2", package="nlmixr2lib"))
```

That made `qs2` a hard `Imports` dependency purely to read data that nlmixr2lib already exports as a lazy-loaded dataset, and coupled nlmixr2shiny to the on-disk format of a file owned by another package.

## Change

Use `nlmixr2lib::modeldb` directly and drop `qs2` from `Imports`.

`nlmixr2lib::modeldb` is the very same object nlmixr2lib writes to its `inst/` copy — both come from the same `modeldb` in `buildModelDb()`. I verified:

```r
identical(nlmixr2lib::modeldb, qs2::qs_read(system.file("modeldb.qs2", package="nlmixr2lib")))
#> TRUE
```

nlmixr2lib has `LazyData: true`, so `nlmixr2lib::modeldb` works without `utils::data()`. This also means nlmixr2shiny keeps working across the nlmixr2lib change from `modeldb.qs2` to `modeldb.rds` (nlmixr2/nlmixr2lib#471) — no fallback needed, since it no longer touches the file at all.

## Testing

With `qs2` hidden from the library, against a patched nlmixr2lib: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 326 ]` — matching the baseline with `qs2` present.

(Against the *released* nlmixr2lib 0.3.2 with qs2 hidden there are 2 failures, but those are in `nlmixr2lib::readModelDb()` itself, which is what nlmixr2/nlmixr2lib#471 fixes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01421WVu1sXnGtEHgrjYwTXy